### PR TITLE
Job event woes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,14 @@ This file documents all notable changes to juttle-client-library. The release nu
 
 ## Current unreleased changes
 
+### Major Changes
+
 - Refetch input definitions when an input value changes [#11]
+
+### Minor Changes
+
+- Add `stop` function to `View` class
+
+### Bug Fixes
+
+- Fix issue with old Jobs not getting stopped on View rerun.

--- a/example/index.html
+++ b/example/index.html
@@ -12,7 +12,8 @@
     <body>
         <div id="root">
             <div id="inputs"></div>
-            <button id="btn-run" class="btn btn-primary">Run Prog</button>
+            <button id="btn-run" class="btn btn-primary">Run Program</button>
+            <button id="btn-stop" class="btn btn-default">Stop Program</button>
             <div id="views"></div>
         </div>
         <script src="/static/bundle.js"></script>

--- a/example/index.js
+++ b/example/index.js
@@ -36,3 +36,7 @@ inputs.render(bundle);
 document.getElementById("btn-run").addEventListener("click", () => {
     view.run(bundle, inputs.getValues());
 });
+
+document.getElementById("btn-stop").addEventListener("click", () => {
+    view.stop();
+});

--- a/src/utils/job-socket.js
+++ b/src/utils/job-socket.js
@@ -14,12 +14,12 @@ export default class JobSocket {
         this._socket.onerror = this._onError.bind(this);
     }
 
-    on(event, listener, context) {
-        this._emitter.on(event, listener, context);
+    on(event, fn, context) {
+        this._emitter.on(event, fn, context);
     }
 
-    send(msg) {
-        this._socket.send(JSON.stringify(msg));
+    once(event, fn, context) {
+        this._emitter.once(event, fn, context);
     }
 
     removeListener(event, fn, context, once) {
@@ -28,6 +28,10 @@ export default class JobSocket {
 
     removeAllListeners(event) {
         this._emitter.removeAllListeners(event);
+    }
+
+    send(msg) {
+        this._socket.send(JSON.stringify(msg));
     }
 
     _onError(event) {
@@ -76,8 +80,14 @@ export default class JobSocket {
     }
 
     close() {
-        this._socket.close();
-        this._socket = null;
+        let self = this;
+
+        // use es6 Promise for now, but we might want to use Bluebird instead
+        // problem is, there's no good way to override Promise in whatwg-fetch
+        return new Promise((resolve, reject) => {
+            self._socket.onclose = resolve;
+            self._socket.close();
+        });
     }
 
 }

--- a/src/view/sink.js
+++ b/src/view/sink.js
@@ -60,6 +60,7 @@ class Sink extends Component {
 
     componentWillUnmount() {
         window.removeEventListener("resize", this._setChartDimensions);
+        this.props.jobEvents.removeListener(this.props.sink.sink_id, this.handleSinkMsg, this);
     }
 
     _setChartDimensions() {


### PR DESCRIPTION
- Shuffled `job-socket` around so we're no longer inheriting from `EventEmitter`
- Fixed bug with rerunning a View that would cause points from separate jobs to get merged.

@go-oleg @davidvgalbraith 