### PR TITLE
Load juttle in example from external file

### DIFF
--- a/example/example.juttle
+++ b/example/example.juttle
@@ -1,0 +1,19 @@
+input name: text;
+
+emit -limit 1000
+| put val = Math.random()
+| put name = name
+| (
+    view timechart -o {
+        id: 'tim',
+        valueField: 'val',
+        row: 0
+    };
+    filter val > 0.5
+    | view events -o {
+        title: 'above .50',
+        on: 'tim'
+    };
+    keep val
+    | view table -row 0;
+)

--- a/example/index.js
+++ b/example/index.js
@@ -2,26 +2,7 @@ import "../sass/main.scss";
 
 import Juttle from "../src";
 
-let program = `
-    input name: text;
-
-    emit -limit 1000
-    | put val = Math.random()
-    | put name = name
-    | (
-        view timechart -o {
-            id: 'tim',
-            valueField: 'val',
-            row: 0
-        };
-        filter val > 0.5
-        | view events -o {
-            title: 'above .50',
-            on: 'tim'
-        };
-        keep val
-        | view table -row 0;
-    )`;
+import program from "./example.juttle";
 
 let client = new Juttle("localhost:8080");
 let bundle = {

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -25,6 +25,10 @@ module.exports = {
                 include: path.join(__dirname, '..')
             },
             {
+                test: /\.juttle$/,
+                loaders: ['raw']
+            },
+            {
                 test: /\.json$/,
                 include: path.join(__dirname, '..'),
                 loader: 'json'

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "mock-socket": "^1.0.6",
     "nock": "^5.2.1",
     "node-sass": "^3.4.2",
+    "raw-loader": "^0.5.1",
     "redux-mock-store": "0.0.6",
     "rimraf": "^2.5.0",
     "sass-loader": "^3.1.2",


### PR DESCRIPTION
Hilariously ran into this issue when trying to run a juttle program that had string interpolation. Found it conflicted with es6's groovy string interplation, when js complained about not finding a var in the program.

@go-oleg 