### PR TITLE
Better Clean for unmounting views

### DIFF
--- a/src/view/view.js
+++ b/src/view/view.js
@@ -59,7 +59,12 @@ class View extends Component {
     }
 
     componentWillUnmount() {
+        // remove event listeners
+        this.props.jobEvents.off(this.props.view.sink_id, this.handleViewMsg, this);
         window.removeEventListener("resize", this._setChartDimensions);
+
+        // destry chart
+        this.componentChart.destroy();
     }
 
     _setChartDimensions() {


### PR DESCRIPTION
Was seeing some weird console log messages because we were not
unsubscribing from jobEvents and destroying the componentChart when the
view unmounted.

@go-oleg 