### PR TITLE
Clear views array on job_create event

### DIFF
--- a/src/view/reducers.js
+++ b/src/view/reducers.js
@@ -4,6 +4,9 @@ import { JOB_START, JOB_CREATED } from "./actions";
 
 function views(state = {}, action) {
     switch (action.type) {
+        // reset views on new job
+        case JOB_CREATED:
+            return {};
 
         case JOB_START:
             let views = {};
@@ -14,6 +17,7 @@ function views(state = {}, action) {
             });
 
             return views;
+
         default:
             return state;
 


### PR DESCRIPTION
Fixes juttle/outrigger#83

When running a different program from our original program, there
was an issue with the old views getting reinstantiated because they
still existed in redux store. This change resets the views in the store
to an empty object so new views are only instantiated when we have info
about them.