### PR TITLE
fix how react-select css is imported

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -41,5 +41,5 @@
 }
 
 .inputs-view {
-    @import "../node_modules/react-select/dist/react-select.css";
+    @import "../node_modules/react-select/dist/react-select";
 }


### PR DESCRIPTION
If the `.css` extension is there, then it ends up being transformed into `url()` css which is not what we want, we want it to be bundled into the build juttle-client-library css file.

http://stackoverflow.com/a/30279590/2359560

@mnibecker 