### PR TITLE
bump juttle-viz version to 0.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "immutable": "^3.7.6",
     "isomorphic-fetch": "^2.2.0",
     "juttle-jsdp": "^0.1.1",
-    "juttle-viz": "^0.3.0",
+    "juttle-viz": "^0.3.1",
     "moment": "^2.11.1",
     "react": "^0.14.3",
     "react-datepicker": "^0.18.0",


### PR DESCRIPTION
Bumping juttle-viz version to get the regression fix in https://github.com/juttle/juttle-viz/pull/32

cc @rlgomes @mnibecker @mstemm 