### PR TITLE
inputs: adding duration input

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-    "plugins": ["transform-class-properties"],
+    "plugins": ["transform-class-properties", "babel-plugin-add-module-exports"],
     "presets": ["react", "es2015"]
 }

--- a/example/.babelrc
+++ b/example/.babelrc
@@ -1,3 +1,4 @@
 {
-    "presets": ["react", "es2015"]
+    "presets": ["react", "es2015"],
+    "plugins": ["babel-plugin-add-module-exports"]
 }

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -3,6 +3,7 @@ var webpack = require('webpack');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 
 module.exports = {
+    devtool: 'cheap-module-eval-source-map',
     entry: [
         './index'
     ],

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-core": "^6.3.21",
     "babel-eslint": "^5.0.0-beta6",
     "babel-loader": "^6.2.0",
+    "babel-plugin-add-module-exports": "^0.1.2",
     "babel-plugin-transform-class-properties": "^6.3.13",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -24,7 +24,6 @@
     .form-control {
         width: 100%;
         display: block;
-        height: 34px;
         padding: 6px 12px;
         font-size: 14px;
         line-height: 1.42;
@@ -47,4 +46,17 @@
 
 .inputs-view {
     @import "../node_modules/react-select/dist/react-select";
+
+    .duration-input {
+        display: flex;
+
+        input {
+            width: 50%;
+            margin-right: 8px;
+        }
+
+        .Select {
+            width: 50%;
+        }
+    }
 }

--- a/src/inputs/components/input-types/duration-input.js
+++ b/src/inputs/components/input-types/duration-input.js
@@ -1,0 +1,124 @@
+import React, { Component } from 'react';
+import Select from 'react-select';
+import moment from 'moment';
+
+const UNITS = [
+    'seconds',
+    'minutes',
+    'hours',
+    'days',
+    'weeks',
+    'months',
+    'years'
+];
+
+const UNITS_FOR_SELECT = UNITS.map((unit) => {
+    return { value: unit, label: unit };
+});
+
+// Do a best effort converting a moment.duration
+// into a numeric value and unit value.
+// Start with the largest unit and down
+// until the duration is a multiple of the unit.
+export function getBestNumValueAndUnit(duration) {
+    let bestUnit = 'minutes';
+    if (duration === null) {
+        return {
+            numValue: null,
+            unit: bestUnit
+        };
+    }
+
+    for (let i = UNITS.length - 1; i >= 0; i--) {
+        if (duration.as(UNITS[i]) % 1 === 0) {
+            bestUnit = UNITS[i];
+            break;
+        }
+    }
+
+    return {
+        numValue : duration.as(bestUnit),
+        unit : bestUnit
+    };
+}
+
+// Returns whether two simple duration objects (containing a numValue and unit)
+// are equivalent. For example, { numValue: 1, unit: "days" } is equivalent
+// to { numValue: 24, unit: "hours" }.
+function areSimpleDurationsEquivalent(value1, value2) {
+    return moment.duration(value1.numValue, value1.unit).asSeconds() === moment.duration(value2.numValue, value2.unit).asSeconds();
+}
+
+class DurationInput extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            value: getBestNumValueAndUnit(props.input.value)
+        };
+    }
+
+    handleUnitChange(value) {
+        this.setState({
+            value: {
+                numValue: this.state.value.numValue,
+                unit: value.value
+            }
+        });
+
+        this.props.inputUpdate(moment.duration(this.state.value.numValue, value.value));
+    }
+
+    handleNumValueChange(event) {
+        let value = parseInt(event.target.value, 10);
+
+        if (value !== value) {
+            return false;
+        }
+
+        this.setState({
+            value: {
+                numValue: value,
+                unit: this.state.value.unit
+            }
+        });
+
+        this.props.inputUpdate(moment.duration(value, this.state.value.unit));
+    }
+
+    componentWillReceiveProps({ input }) {
+        let newValue = getBestNumValueAndUnit(input.value);
+
+        // If the new value is equal to the old value, keep the old value
+        // so we don't unnecessarily change the numeric value and unit for the user.
+        if (areSimpleDurationsEquivalent(newValue, this.state.value)) {
+            return;
+        }
+
+        this.setState({
+            value: newValue
+        });
+    }
+
+    render() {
+        let { numValue, unit } = this.state.value;
+
+        return (
+            <div className='form-group'>
+                <input
+                    type={'number'}
+                    value={numValue}
+                    onChange={this.handleNumValueChange.bind(this)}
+                />
+                <Select
+                    name='form-field-name'
+                    value={unit}
+                    options={UNITS_FOR_SELECT}
+                    clearable={false}
+                    onChange={this.handleUnitChange.bind(this)}
+                />
+            </div>
+        );
+    }
+}
+
+export default DurationInput;

--- a/src/inputs/components/input-types/duration-input.js
+++ b/src/inputs/components/input-types/duration-input.js
@@ -71,7 +71,7 @@ class DurationInput extends Component {
     handleNumValueChange(event) {
         let value = parseInt(event.target.value, 10);
 
-        if (value !== value) {
+        if (Number.isNaN(value)) {
             return false;
         }
 

--- a/src/inputs/components/input-types/duration-input.js
+++ b/src/inputs/components/input-types/duration-input.js
@@ -103,8 +103,9 @@ class DurationInput extends Component {
         let { numValue, unit } = this.state.value;
 
         return (
-            <div className='form-group'>
+            <div className='form-group duration-input'>
                 <input
+                    className='form-control'
                     type={'number'}
                     value={numValue}
                     onChange={this.handleNumValueChange.bind(this)}

--- a/src/inputs/components/input-types/index.js
+++ b/src/inputs/components/input-types/index.js
@@ -2,10 +2,12 @@ import TextInput from './text-input';
 import NumberInput from './number-input';
 import SelectInput from './select-input';
 import DateInput from './date-input';
+import DurationInput from './duration-input';
 
 export default {
     text: TextInput,
     number: NumberInput,
     select: SelectInput,
-    date: DateInput
+    date: DateInput,
+    duration: DurationInput
 };

--- a/test/inputs/components/duration.spec.js
+++ b/test/inputs/components/duration.spec.js
@@ -1,0 +1,55 @@
+import { getBestNumValueAndUnit } from '../../../src/inputs/components/input-types/duration-input';
+import moment from 'moment';
+import { expect } from 'chai';
+
+describe('duration input', () => {
+    describe('getBestNumValueAndUnit', () => {
+        it('1 second', () => {
+            expect(getBestNumValueAndUnit(moment.duration(1, 'seconds'))).to.deep.equal({ numValue: 1, unit: 'seconds'});
+        });
+
+        it('60 seconds', () => {
+            expect(getBestNumValueAndUnit(moment.duration(60, 'seconds'))).to.deep.equal({ numValue: 1, unit: 'minutes'});
+        });
+
+        it('61 seconds', () => {
+            expect(getBestNumValueAndUnit(moment.duration(61, 'seconds'))).to.deep.equal({ numValue: 61, unit: 'seconds'});
+        });
+
+        it('60 minutes', () => {
+            expect(getBestNumValueAndUnit(moment.duration(60, 'minutes'))).to.deep.equal({ numValue: 1, unit: 'hours'});
+        });
+
+        it('61 minutes', () => {
+            expect(getBestNumValueAndUnit(moment.duration(61, 'minutes'))).to.deep.equal({ numValue: 61, unit: 'minutes'});
+        });
+
+        it('24 hours', () => {
+            expect(getBestNumValueAndUnit(moment.duration(24, 'hours'))).to.deep.equal({ numValue: 1, unit: 'days'});
+        });
+
+        it('25 hours', () => {
+            expect(getBestNumValueAndUnit(moment.duration(25, 'hours'))).to.deep.equal({ numValue: 25, unit: 'hours'});
+        });
+
+        it('7 days', () => {
+            expect(getBestNumValueAndUnit(moment.duration(7, 'days'))).to.deep.equal({ numValue: 1, unit: 'weeks'});
+        });
+
+        it('8 days', () => {
+            expect(getBestNumValueAndUnit(moment.duration(8, 'days'))).to.deep.equal({ numValue: 8, unit: 'days'});
+        });
+
+        it('1 month', () => {
+            expect(getBestNumValueAndUnit(moment.duration(1, 'months'))).to.deep.equal({ numValue: 1, unit: 'months'});
+        });
+
+        it('12 months', () => {
+            expect(getBestNumValueAndUnit(moment.duration(12, 'months'))).to.deep.equal({ numValue: 1, unit: 'years'});
+        });
+
+        it('13 months', () => {
+            expect(getBestNumValueAndUnit(moment.duration(13, 'months'))).to.deep.equal({ numValue: 13, unit: 'months'});
+        });
+    });
+});


### PR DESCRIPTION
Add duration input.

The duration input is a little different from the other inputs in that it internally maintains a special representation of the current value so that we can limit how much we change its UI component values. For example, if a user increments from 59 minutes to 60 minutes, we want to keep showing the 60 minutes instead of 1 hour (which we would otherwise show when converting a `moment.duration` to its "best" number and unit representation).

Also added a couple small changes to babelrc and webpack config (see individual commits).

@mnibecker @davidvgalbraith 