### PR TITLE
Views clear fn

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -15,6 +15,7 @@
             <button id="btn-run" class="btn btn-primary">Run Program</button>
             <button id="btn-stop" class="btn btn-default">Stop Program</button>
             <button id="btn-clear-errors" class="btn btn-default">Clear Errors</button>
+            <button id="btn-clear-view" class="btn btn-default">Clear View</button>
             <div id="views"></div>
             <div id="error"></div>
         </div>

--- a/example/index.js
+++ b/example/index.js
@@ -31,3 +31,7 @@ document.getElementById('btn-stop').addEventListener('click', () => {
 document.getElementById('btn-clear-errors').addEventListener('click', () => {
     error.clear();    
 });
+
+document.getElementById('btn-clear-view').addEventListener('click', () => {
+    view.clear();
+});

--- a/src/utils/job-socket.js
+++ b/src/utils/job-socket.js
@@ -60,7 +60,9 @@ export default class JobSocket {
         // use es6 Promise for now, but we might want to use Bluebird instead
         // problem is, there's no good way to override Promise in whatwg-fetch
         return new Promise((resolve, reject) => {
-            self._socket.onclose = resolve;
+            self._emitter.once('close', () => {
+                resolve();
+            });
             self._socket.close();
         });
     }

--- a/src/view/actions.js
+++ b/src/view/actions.js
@@ -1,5 +1,6 @@
 export const JOB_START = 'JOB_START';
 export const JOB_CREATED = 'JOB_CREATED';
+export const CLEAR_JOB = 'CLEAR_JOB';
 
 export function jobCreated(job_id) {
     return {
@@ -12,5 +13,11 @@ export function jobStart(views) {
     return {
         type: JOB_START,
         views
+    };
+}
+
+export function clearJob() {
+    return {
+        type: CLEAR_JOB
     };
 }

--- a/src/view/index.js
+++ b/src/view/index.js
@@ -9,7 +9,7 @@ import reducers from './reducers';
 import OutriggerAPI from '../utils/api';
 import JobSocket from '../utils/job-socket';
 import EventEmitter from 'eventemitter3';
-import { jobCreated, jobStart } from './actions';
+import { jobCreated, jobStart, clearJob } from './actions';
 
 export default class View {
     constructor(outriggerUrl, el) {
@@ -63,6 +63,15 @@ export default class View {
             self._starting = false;
 
             return self.jobEvents;
+        });
+    }
+
+    clear() {
+        let { dispatch } = this.store;
+
+        return this.stop()
+        .then(() => {
+            dispatch(clearJob());
         });
     }
 

--- a/src/view/reducers.js
+++ b/src/view/reducers.js
@@ -1,11 +1,12 @@
 import { combineReducers } from 'redux';
 
-import { JOB_START, JOB_CREATED } from './actions';
+import { JOB_START, JOB_CREATED, CLEAR_JOB } from './actions';
 
 function views(state = {}, action) {
     switch (action.type) {
         // reset views on new job
         case JOB_CREATED:
+        case CLEAR_JOB:
             return {};
 
         case JOB_START:
@@ -29,6 +30,8 @@ function job_id(state = null, action) {
 
         case JOB_CREATED:
             return action.job_id;
+        case CLEAR_JOB:
+            return null;
         default:
             return state;
 


### PR DESCRIPTION
add `view.clear()` which stops the current job and resets views.

also fixed bug I found with stopping and starting a view not working (should probably add a unit test for this)