### PR TITLE
Juttle view errors 2

### DIFF
--- a/src/utils/error-messages.js
+++ b/src/utils/error-messages.js
@@ -1,5 +1,5 @@
 export default {
-    'JOB-START-ERROR': 'Event \'job_start\' not received as first message from socket. Problem.',
-    'JUTTLE-VIEW-PARAMS-INVALID': 'The following views have invalid parameters: {{info.viewNames}}',
+    'JOB-START-ERROR': 'Event \"job_start\" not received as first message from socket. Problem.',
+    'JUTTLE-VIEW-PARAMS-INVALID': '\"{{info.juttleView}}\" has invalid parameters: {{info.errorMessages}}',
     'JUTTLE-VIEW-UNKNOWN-ERROR': 'Unknown/Unsupported view type: {{info.type}}'
 };

--- a/src/view/juttle-view-gen.js
+++ b/src/view/juttle-view-gen.js
@@ -5,7 +5,6 @@ import errors from '../utils/errors';
 
 export default (views) => {
     let juttleViews = {};
-    let viewErrors = [];
     views.forEach(view => {
         var juttleViewConstructorOptions = {
             params: _.omit(view.options, '_jut_time_bounds'),
@@ -31,16 +30,20 @@ export default (views) => {
             );
         }
         catch (err) {
-            viewErrors.push(err.info);
+            let flattenedError = ViewConstructor.getFlattenedParamValidationErrors(err.info.errors);
+            let errorMessages = _.chain(flattenedError)
+               .values()
+               .pluck(0)
+               .pluck('message')
+               .value();
+
+            throw new errors.JuttleViewParamsError({
+                juttleView: err.info.sinkName,
+                errorMessages: errorMessages.join(' '),
+                detail: flattenedError
+            });
         }
     });
-
-    if (viewErrors.length > 0) {
-        throw new errors.JuttleViewParamsError({
-            detail: viewErrors,
-            viewNames: _.pluck(viewErrors, 'sinkName').join(', ')
-        });
-    }
 
     return juttleViews;
 };

--- a/test/views/juttle-view-gen.spec.js
+++ b/test/views/juttle-view-gen.spec.js
@@ -42,25 +42,26 @@ describe('test view component generator', () => {
             }]);
         } catch (err) {
             expect(err.code).to.equal('JUTTLE-VIEW-PARAMS-INVALID');
-            expect(err.message).to.equal('The following views have invalid parameters: timechart');
+            expect(err.message).to.have.string('"timechart" has invalid parameters:');
+            expect(err.message).to.have.string('unknown_option');
             return;
         }
 
         throw new Error('Expected error here');
     });
 
-    it('two invalid components throw error', () => {
+    it('two invalid views throw error on first juttleView', () => {
         try {
             juttleViewGen([
                 {
-                    type: 'timechart',
+                    type: 'barchart',
                     sink_id: 'view0',
                     options: {
                         'unknown_option': true
                     }
                 },
                 {
-                    type: 'barchart',
+                    type: 'timechart',
                     sink_id: 'view1',
                     options: {
                         'unknown_option': true
@@ -69,7 +70,8 @@ describe('test view component generator', () => {
             ]);
         } catch (err) {
             expect(err.code).to.equal('JUTTLE-VIEW-PARAMS-INVALID');
-            expect(err.message).to.equal('The following views have invalid parameters: timechart, barchart');
+            expect(err.message).to.have.string('"barchart" has invalid parameters:');
+            expect(err.message).to.have.string('unknown_option');
             return;
         }
 


### PR DESCRIPTION
Previously we were reporting very general errors for multiple views.
Instead throw error at first instantiated view error and render
detailed information.

@go-oleg 