### PR TITLE
text and number input: submit value when enter is pressed

### DIFF
--- a/src/inputs/components/input-types/number-input.js
+++ b/src/inputs/components/input-types/number-input.js
@@ -3,8 +3,8 @@ import TextInput from './text-input';
 class NumberInput extends TextInput {
     getType() { return 'number'; }
 
-    _onBlur(event) {
-        let value = parseInt(event.target.value, 10);
+    _submitValueFromInputEl(value) {
+        value = parseInt(value, 10);
         if (value !== value) {
             return false;
         }

--- a/src/inputs/components/input-types/text-input.js
+++ b/src/inputs/components/input-types/text-input.js
@@ -1,5 +1,7 @@
 import React, { Component } from 'react';
 
+const ENTER_KEY = 13;
+
 class TextInput extends Component {
     constructor(props) {
         super(props);
@@ -15,8 +17,18 @@ class TextInput extends Component {
         this.setState({ value: event.target.value});
     }
 
+    _submitValueFromInputEl(value) {
+        this.props.inputUpdate(value);
+    }
+
     _onBlur(event) {
-        this.props.inputUpdate(event.target.value);
+        this._submitValueFromInputEl(event.target.value);
+    }
+
+    _onKeyDown(event) {
+        if (event.keyCode === ENTER_KEY) {
+            this._submitValueFromInputEl(event.target.value);
+        }
     }
 
     componentWillReceiveProps(nextProps) {
@@ -34,6 +46,7 @@ class TextInput extends Component {
                 <input
                     type={this.getType()}
                     className="form-control"
+                    onKeyDown={this._onKeyDown.bind(this)}
                     onBlur={this._onBlur.bind(this)}
                     onChange={this._onChange.bind(this)}
                     value={currentValue} />


### PR DESCRIPTION
With this change, hitting enter when focused on a text or number input submits its value to the store (i.e. has the same effect as blurring). This is convenient because hitting **enter** is a typical cue that a user is done with editing the value. The other somewhat _coupled_ (and not the most elegant) reason is that when a user hits **enter**, we want to make sure the value is submitted before rerunning the juttle program in https://github.com/juttle/juttle-viewer/pull/20.

@mnibecker 