### PR TITLE
Subscribe to job events in view

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -14,6 +14,14 @@ let view = new client.View(document.getElementById('views'));
 let inputs = new client.Input(document.getElementById('inputs'));
 let error = new client.Errors(document.getElementById('error'));
 
+// handle runtime errors
+view.on('error', runtimeError.bind(null, 'error'));
+view.on('warning', runtimeError.bind(null, 'warning'));
+
+function runtimeError(type, err) {
+    error.render(err);
+}
+
 inputs.render(bundle)
 .catch(err => {
     error.render(err);

--- a/src/view/index.js
+++ b/src/view/index.js
@@ -40,6 +40,8 @@ export default class View extends EventTarget {
                     juttleViews={juttleViews} />,
                 this.el
             );
+
+            return res;
         })
         .catch(err => {
             return self._jobManager.close()

--- a/src/view/index.js
+++ b/src/view/index.js
@@ -1,24 +1,25 @@
 import React from 'react';
 import * as ReactDOM from 'react-dom';
-import EventEmitter from 'eventemitter3';
 
+import EventTarget from '../utils/event-target';
 import ViewLayout from './view-layout';
 import JobManager from '../utils/job-manager';
 import viewLayoutGen from './view-layout-gen';
 import juttleViewGen from './juttle-view-gen';
 
-export default class View {
+export default class View extends EventTarget {
     constructor(outriggerUrl, el) {
+        super();
+
         this.el = el;
         this.outriggerUrl = outriggerUrl;
-        this.jobEvents = new EventEmitter();
 
         // setup _jobManager
         this._jobManager = new JobManager(outriggerUrl);
         this._jobManager.on('message', this._onMessage, this);
 
         ReactDOM.render(
-            <ViewLayout jobEvents={this.jobEvents}/>,
+            <ViewLayout jobEvents={this._emitter}/>,
             this.el
         );
     }
@@ -34,13 +35,11 @@ export default class View {
             ReactDOM.render(
                 <ViewLayout
                     key={res.job_id}
-                    jobEvents={this.jobEvents}
+                    jobEvents={this._emitter}
                     viewLayout={viewLayout}
                     juttleViews={juttleViews} />,
                 this.el
             );
-
-            // return this.jobEvents;
         })
         .catch(err => {
             return self._jobManager.close()
@@ -61,9 +60,9 @@ export default class View {
 
     _onMessage(msg) {
         if (msg.type === 'warning' || msg.type === 'error') {
-            this.jobEvents.emit(msg.type, msg[msg.type]);
+            this._emitter.emit(msg.type, msg[msg.type]);
         } else {
-            this.jobEvents.emit(msg.sink_id, msg);
+            this._emitter.emit(msg.sink_id, msg);
         }
     }
 


### PR DESCRIPTION
Was needed in order for rendering runtime errors in juttle-viewer. Why
not make the View class inherit `event-target` and provide the ability
to listen to all events.

@go-oleg 