### PR TITLE
Bump version of mock-socket

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "jsdom": "^8.0.2",
     "json-loader": "^0.5.4",
     "mocha": "^2.3.4",
-    "mock-socket": "^1.0.6",
+    "mock-socket": "^2.0.0",
     "nock": "^5.2.1",
     "node-sass": "^3.4.2",
     "raw-loader": "^0.5.1",
@@ -63,7 +63,6 @@
   "dependencies": {
     "bluebird": "^3.2.2",
     "eventemitter3": "^1.1.1",
-    "immutable": "^3.7.6",
     "isomorphic-fetch": "^2.2.0",
     "juttle-jsdp": "^0.1.1",
     "juttle-viz": "^0.4.0",

--- a/test/utils/job-manager.spec.js
+++ b/test/utils/job-manager.spec.js
@@ -40,13 +40,6 @@ describe('job-socket', function() {
 
     before(() => {
         global.WebSocket = WebSocket;
-
-        // an unholy hack going on here.
-        // can remove once https://github.com/thoov/mock-socket/issues/71 is resolved
-        if (global.window) {
-            global.window.Event = undefined;
-            global.window.MessageEvent = undefined;
-        }
     });
 
     after(() => {


### PR DESCRIPTION
There was an issue with the previous version that required a hack in the
socket-manager test. The release of 2.0.0 has fixed this issue.

Also, removed immutable from package.json (it wasn't being used).

@go-oleg 