### PR TITLE
expect websocket messages to contain view* instead of sink* properties

### DIFF
--- a/sass/main.scss
+++ b/sass/main.scss
@@ -4,7 +4,7 @@
     @import "flexbox";
     @import "variables";
 
-    &.sink-views {
+    &.views-layout {
         @include flex-grow(1);
     }
 

--- a/src/utils/job-manager.js
+++ b/src/utils/job-manager.js
@@ -49,7 +49,7 @@ export default class JobSocket extends EventTarget {
                     self._socket.onmessage = self._onMessage.bind(this);
                     resolve({
                         job_id: job.job_id,
-                        views: msg.sinks
+                        views: msg.views
                     });
                 };
             });

--- a/src/view/index.js
+++ b/src/view/index.js
@@ -64,7 +64,7 @@ export default class View extends EventTarget {
         if (msg.type === 'warning' || msg.type === 'error') {
             this._emitter.emit(msg.type, msg[msg.type]);
         } else {
-            this._emitter.emit(msg.sink_id, msg);
+            this._emitter.emit(msg.view_id, msg);
         }
     }
 

--- a/src/view/juttle-view-gen.js
+++ b/src/view/juttle-view-gen.js
@@ -24,7 +24,7 @@ export default (views) => {
         }
 
         try {
-            juttleViews[view.sink_id] = new ViewConstructor(
+            juttleViews[view.view_id] = new ViewConstructor(
                 juttleViewConstructorOptions,
                 _.values(juttleViews)
             );

--- a/src/view/view-layout-gen.js
+++ b/src/view/view-layout-gen.js
@@ -47,7 +47,7 @@ export default (viewArr) => {
         // clean this up a bit
         let arr = [];
         views.forEach((view) => {
-            arr.push(view.sink_id);
+            arr.push(view.view_id);
         });
 
         return arr;

--- a/src/view/view-layout.js
+++ b/src/view/view-layout.js
@@ -41,7 +41,7 @@ class ViewLayout extends Component {
         });
 
         return (
-            <div className="juttle-client-library sink-views">
+            <div className="juttle-client-library views-layout">
                 {rows}
             </div>
         );

--- a/src/view/view.js
+++ b/src/view/view.js
@@ -13,7 +13,7 @@ class View extends Component {
             case 'tick':
                 this.props.juttleView.consume_tick(msg.time);
                 break;
-            case 'sink_end':
+            case 'view_end':
                 this.props.juttleView.consume_eof();
                 break;
 

--- a/test/utils/job-manager.spec.js
+++ b/test/utils/job-manager.spec.js
@@ -14,9 +14,9 @@ const bogusBundle = {
 };
 const bogusJobStart = {
     type: 'job_start',
-    sinks: [{
+    views: [{
         type: 'logger',
-        sink_id: 'view0'
+        view_id: 'view0'
     }]
 };
 
@@ -117,7 +117,7 @@ describe('job-socket', function() {
                 mockSocketServer.send(JSDP.serialize({
                     time: sampleDate,
                     type: 'mark',
-                    sink: 'sink0'
+                    view: 'view0'
                 }));
             });
         });
@@ -147,7 +147,7 @@ describe('job-socket', function() {
                 });
 
                 mockSocketServer.send(JSDP.serialize({
-                    sink_id: 'sink0',
+                    view_id: 'view0',
                     points: points
                 }));
             });
@@ -160,7 +160,7 @@ describe('job-socket', function() {
             const views = [
                 {
                     type: 'logger',
-                    sink_id: 'sink0',
+                    view_id: 'view0',
                     options: {
                         _jut_time_bounds: [
                             {
@@ -178,7 +178,7 @@ describe('job-socket', function() {
                 },
                 {
                     type: 'table',
-                    sink_id: 'sink1',
+                    view_id: 'view1',
                     options: {
                         _jut_time_bounds: [
                             {

--- a/test/views/juttle-view-gen.spec.js
+++ b/test/views/juttle-view-gen.spec.js
@@ -12,7 +12,7 @@ describe('test view component generator', () => {
         let components = juttleViewGen([
             {
                 type: 'timechart',
-                sink_id: 'view0',
+                view_id: 'view0',
                 options: {
                     'row': 0,
                     '_jut_time_bounds': []
@@ -20,7 +20,7 @@ describe('test view component generator', () => {
             },
             {
                 type: 'table',
-                sink_id: 'view1',
+                view_id: 'view1',
                 options: {
                     'row': 0,
                     '_jut_time_bounds': []
@@ -35,7 +35,7 @@ describe('test view component generator', () => {
         try {
             juttleViewGen([{
                 type: 'timechart',
-                sink_id: 'view0',
+                view_id: 'view0',
                 options: {
                     'unknown_option': true
                 }
@@ -55,14 +55,14 @@ describe('test view component generator', () => {
             juttleViewGen([
                 {
                     type: 'barchart',
-                    sink_id: 'view0',
+                    view_id: 'view0',
                     options: {
                         'unknown_option': true
                     }
                 },
                 {
                     type: 'timechart',
-                    sink_id: 'view1',
+                    view_id: 'view1',
                     options: {
                         'unknown_option': true
                     }
@@ -82,7 +82,7 @@ describe('test view component generator', () => {
         try {
             juttleViewGen([{
                 type: 'does_not_exist',
-                sink_id: 'view0',
+                view_id: 'view0',
                 options: {}
             }]);
         } catch (err) {

--- a/test/views/view-layout-gen.spec.js
+++ b/test/views/view-layout-gen.spec.js
@@ -7,11 +7,11 @@ describe('test view-layout generator', () => {
         let layout = viewLayoutGen([
             {
                 options: { row: 1 },
-                sink_id: 'view_1'
+                view_id: 'view_1'
             },
             {
                 options: { row: 1 },
-                sink_id: 'view_2'
+                view_id: 'view_2'
             }
         ]);
 
@@ -24,15 +24,15 @@ describe('test view-layout generator', () => {
         let layout = viewLayoutGen([
             {
                 options: { row: 1 },
-                sink_id: 'view_3'
+                view_id: 'view_3'
             },
             {
                 options: { row: 1, col: 2 },
-                sink_id: 'view_2'
+                view_id: 'view_2'
             },
             {
                 options: { row: 1, col: 1},
-                sink_id: 'view_1'
+                view_id: 'view_1'
             }
         ]);
 
@@ -43,9 +43,9 @@ describe('test view-layout generator', () => {
 
     it('unspecified views should render in default order', () => {
         let layout = viewLayoutGen([
-            { sink_id: 'view_1' },
-            { sink_id: 'view_2' },
-            { sink_id: 'view_3' }
+            { view_id: 'view_1' },
+            { view_id: 'view_2' },
+            { view_id: 'view_3' }
         ]);
 
         expect(layout).to.deep.equal([


### PR DESCRIPTION
To match changes made in https://github.com/juttle/juttle-service/pull/47.

Also modify a couple other places where the term 'sink' was used.

@mnibecker 

(will merge once a version of juttle-service containing https://github.com/juttle/juttle-service/pull/47 is published)