### PR TITLE
fix export in src/index.js so it works properly with commonjs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,7 @@ import View from './view';
 import JuttleServiceHttp from './utils/http-api';
 import Errors from './errors';
 
-export default function Juttle(juttleServiceUrl) {
+function Juttle(juttleServiceUrl) {
     this.juttleServiceUrl = juttleServiceUrl;
     this.api = new JuttleServiceHttp(`http://${juttleServiceUrl}`);
 
@@ -21,3 +21,5 @@ export default function Juttle(juttleServiceUrl) {
     this.View = View.bind(null, this.juttleServiceUrl);
     this.Errors = Errors;
 }
+
+export default Juttle;


### PR DESCRIPTION
```
export default function Juttle ...
```
wasn't getting properly converted by [babel-plugin-add-module-exports](https://github.com/59naga/babel-plugin-add-module-exports/) to work with commonjs `require()`.

The change here makes it work. Didn't look into if this a bug in `babel-plugin-add-module-exports` because this feels nicer anyways.

@mnibecker 