### PR TITLE
job-manager: job-status events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 This file documents all notable changes to juttle-client-library. The release numbering uses [semantic versioning](http://semver.org).
 
+## Unreleased Changes
+
+### Minor Changes
+- Change job-manager status to `CONNECTING`, `RUNNING` and `STOPPED`. Add subscribable `job-status` event to `job-manager` and `View` class. [#62](https://github.com/juttle/juttle-client-library/pull/62)
+
 ## 0.6.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,7 @@ Released 2016-02-12
 ### Major Changes
 - change input.getValues to return a promise and text/number input to update onBlur [[#43](https://github.com/juttle/juttle-client-library/pull/43)]
 
-
-## Unreleased Changes
+## 0.3.0 
 
 ### Major Changes
 - Add error reporting for invalid JuttleView parameters.

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "redux-mock-store": "0.0.6",
     "rimraf": "^2.5.0",
     "sass-loader": "^3.1.2",
+    "sinon": "^1.17.3",
+    "sinon-chai": "^2.8.0",
     "style-loader": "^0.13.0",
     "webpack": "^1.12.9",
     "webpack-dev-middleware": "^1.4.0"

--- a/src/utils/job-manager.js
+++ b/src/utils/job-manager.js
@@ -38,8 +38,8 @@ export default class JobSocket extends EventTarget {
             return new Promise((resolve, reject) => {
                 let socketUrl = `ws://${this.host}${API_PREFIX}/jobs/${job.job_id}`;
                 self._socket = new WebSocket(socketUrl);
-                self._socket.onopen = this._onOpenOrClose;
-                self._socket.onclose = this._onOpenOrClose;
+                self._socket.onopen = this._onOpen;
+                self._socket.onclose = this._onClose;
                 self._socket.onerror = this._onError;
 
                 // make sure first message is job_start
@@ -71,13 +71,14 @@ export default class JobSocket extends EventTarget {
         this._socket.send(JSON.stringify(msg));
     }
 
-    _onOpenOrClose = (event) => {
-        if (event.type === 'open') {
-            this._setStatus(JobStatus.RUNNING);
-        } else {
-            this._setStatus(JobStatus.STOPPED);
-        }
-        this._emitter.emit(event.type, event);
+    _onOpen = (event) => {
+        this._setStatus(JobStatus.RUNNING);
+        this._emitter.emit('open', event);
+    };
+
+    _onClose = (event) => {
+        this._setStatus(JobStatus.STOPPED);
+        this._emitter.emit('close', event);
     };
 
     _onError = (event) => {

--- a/src/view/index.js
+++ b/src/view/index.js
@@ -17,6 +17,9 @@ export default class View extends EventTarget {
         // setup _jobManager
         this._jobManager = new JobManager(juttleServiceUrl);
         this._jobManager.on('message', this._onMessage, this);
+        this._jobManager.on('job-status', (status) => {
+            this._emitter.emit('job-status', status);
+        });
 
         ReactDOM.render(
             <ViewLayout jobEvents={this._emitter}/>,

--- a/test/utils/job-manager.spec.js
+++ b/test/utils/job-manager.spec.js
@@ -66,17 +66,16 @@ describe('job-socket', function() {
     });
 
     describe('admin functionality', () => {
-        it('actually closes socket on stop', (done) => {
+        it('actually closes socket on stop', () => {
             mockSocketServer = createSocketServer();
 
-            jobManager.start(bogusBundle)
+            return jobManager.start(bogusBundle)
             .then(() => {
-                expect(jobManager.getStatus()).to.equal(JobStatus.OPEN);
+                expect(jobManager.status).to.equal(JobStatus.RUNNING);
                 return jobManager.close();
             })
             .then(() => {
-                expect(jobManager.getStatus()).to.equal(JobStatus.CLOSED);
-                done();
+                expect(jobManager.status).to.equal(JobStatus.STOPPED);
             });
         });
 
@@ -121,7 +120,11 @@ describe('job-socket', function() {
             })
             .then(() => {
                 expect(cb).to.have.callCount(3);
-                expect(cb.args).to.deep.equal([ [0], [1], [3] ]);
+                expect(cb.args).to.deep.equal([
+                    [JobStatus.STARTING],
+                    [JobStatus.RUNNING],
+                    [JobStatus.STOPPED]
+                ]);
             });
         });
 
@@ -143,11 +146,11 @@ describe('job-socket', function() {
                 return jobManager.close();
             })
             .then(() => {
-                // because mock-socket close happens synchronously, we miss the
-                // CLOSING event. Replace two lines below with one line below
-                // once thoov/mock-socket#76
-                // expect(cb.args).to.deep.equal([ [0], [1], [2], [3] ]);
-                expect(cb.args).to.deep.equal([ [0], [1], [3] ]);
+                expect(cb.args).to.deep.equal([
+                    [JobStatus.STARTING],
+                    [JobStatus.RUNNING],
+                    [JobStatus.STOPPED]
+                ]);
                 expect(cb).to.have.callCount(3);
             });
         });

--- a/test/utils/job-manager.spec.js
+++ b/test/utils/job-manager.spec.js
@@ -1,9 +1,13 @@
 import { WebSocket, Server } from 'mock-socket';
 import nock from 'nock';
-import { expect } from 'chai';
+import chai from 'chai';
+import sinon from 'sinon'   ;
+import sinonChai from 'sinon-chai';
 import JobManager, { JobStatus } from '../../src/utils/job-manager';
 import JSDP from 'juttle-jsdp';
 
+let expect = chai.expect;
+chai.use(sinonChai);
 
 const API_PREFIX = '/api/v0';
 
@@ -61,7 +65,7 @@ describe('job-socket', function() {
         });
     });
 
-    describe('admin functionality', (done) => {
+    describe('admin functionality', () => {
         it('actually closes socket on stop', (done) => {
             mockSocketServer = createSocketServer();
 
@@ -89,6 +93,62 @@ describe('job-socket', function() {
                 });
 
                 mockSocketServer.send({ type: 'ping' });
+            });
+        });
+    });
+
+    describe('status-change events', () => {
+        // disable until thoov/mock-socket#74 is resolved
+        it.skip('receive proper job-status events on job closed from server', () => {
+            mockSocketServer = createSocketServer();
+
+            let cb = sinon.spy();
+            jobManager.on('job-status', cb);
+
+            return jobManager.start(bogusBundle)
+            .then(() => {
+                // send a bogus messages
+                mockSocketServer.send(JSDP.serialize({
+                    time: new Date(2000),
+                    type: 'mark',
+                    view: 'view0'
+                }));
+
+                return new Promise(resolve => {
+                    jobManager.on('close', resolve);
+                    mockSocketServer.close();
+                });
+            })
+            .then(() => {
+                expect(cb).to.have.callCount(3);
+                expect(cb.args).to.deep.equal([ [0], [1], [3] ]);
+            });
+        });
+
+        it('receive proper job-status events on job terminated from client', () => {
+            mockSocketServer = createSocketServer();
+
+            let cb = sinon.spy();
+            jobManager.on('job-status', cb);
+
+            return jobManager.start(bogusBundle)
+            .then(() => {
+                // send a bogus messages
+                mockSocketServer.send(JSDP.serialize({
+                    time: new Date(2000),
+                    type: 'mark',
+                    view: 'view0'
+                }));
+
+                return jobManager.close();
+            })
+            .then(() => {
+                // because mock-socket close happens synchronously, we miss the
+                // CLOSING event. Replace two lines below with one line below
+                // once thoov/mock-socket#76
+                // expect(cb.args).to.deep.equal([ [0], [1], [2], [3] ]);
+                expect(cb.args).to.deep.equal([ [0], [1], [3] ]);
+                expect(cb).to.have.callCount(3);
             });
         });
     });


### PR DESCRIPTION
When the readyState of the internal WebSocket changes, fire job-status
event. Hook this event to the view class so users can subscribe to it as
well. Event returns the JobStatus code of the job (0= CONNECTING,
1= OPEN, etc)

Arose from a need in juttle-viewer to keep track of the status of a
running job. Now we have it.

@go-oleg 