### PR TITLE
webpack: fix umd config to export as library as JuttleClientLibrary

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
         new webpack.NoErrorsPlugin()
     ],
     output: {
-        output: 'juttle-client-library',
+        library: "JuttleClientLibrary",
         libraryTarget: 'umd'
     },
     module: {


### PR DESCRIPTION
based on https://webpack.github.io/docs/webpack-for-browserify-users.html#standalone

@mnibecker 