### PR TITLE
add: debug log support

### DIFF
--- a/src/utils/http-api.js
+++ b/src/utils/http-api.js
@@ -29,22 +29,24 @@ function makeRequest(uri, options) {
 }
 
 export function getInputs (url, bundle, inputs = {}) {
+    let body = {
+        bundle,
+        inputs: JSDP.serialize(inputs, { toObject: true })
+    };
+    
     return makeRequest(`${url}${API_PREFIX}/prepare`, {
         method: 'post',
         headers: {
             'Content-Type': 'application/json'
         },
-        body: JSON.stringify({
-            bundle,
-            inputs: JSDP.serialize(inputs, { toObject: true })
-        })
+        body: JSON.stringify(body)
     })
     .then(parsedBody => JSDP.deserialize(parsedBody));
 }
 
 export function runJob(url, bundle, inputs = {}, addDebugLogs = false) {
     
-    var body = {
+    let body = {
         bundle,
         inputs: JSDP.serialize(inputs, { toObject: true }),
         debug: addDebugLogs

--- a/src/utils/http-api.js
+++ b/src/utils/http-api.js
@@ -42,17 +42,21 @@ export function getInputs (url, bundle, inputs = {}) {
     .then(parsedBody => JSDP.deserialize(parsedBody));
 }
 
-export function runJob(url, bundle, inputs = {}) {
+export function runJob(url, bundle, inputs = {}, addDebugLogs = false) {
+    
+    var body = {
+        bundle,
+        inputs: JSDP.serialize(inputs, { toObject: true }),
+        debug: addDebugLogs
+    };
+    
     return makeRequest(`${url}${API_PREFIX}/jobs`, {
         method: 'post',
         headers: {
             'Accept': 'application/json',
             'Content-Type': 'application/json'
         },
-        body: JSON.stringify({
-            bundle,
-            inputs: JSDP.serialize(inputs, { toObject: true })
-        })
+        body: JSON.stringify(body)
     });
 }
 

--- a/src/utils/job-manager.js
+++ b/src/utils/job-manager.js
@@ -25,14 +25,14 @@ export default class JobSocket extends EventTarget {
         this.status = JobStatus.STOPPED;
     }
 
-    start(bundle, inputValues) {
+    start(bundle, inputValues, addDebugLogs) {
         let self = this;
 
         this._setStatus(JobStatus.STARTING);
 
         return this.close()
         .then(() => {
-            return http.runJob(`http://${this.host}`, bundle, inputValues);
+            return http.runJob(`http://${this.host}`, bundle, inputValues, addDebugLogs);
         })
         .then(job => {
             return new Promise((resolve, reject) => {

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -27,10 +27,10 @@ export default class View extends EventTarget {
         );
     }
 
-    run(bundle, inputValues) {
+    run(bundle, inputValues, addDebugLogs) {
         let self = this;
 
-        return this._jobManager.start(bundle, inputValues)
+        return this._jobManager.start(bundle, inputValues, addDebugLogs)
         .then(res => {
             let juttleViews = juttleViewGen(res.views);
             let viewLayout = viewLayoutGen(res.views);
@@ -66,6 +66,8 @@ export default class View extends EventTarget {
     _onMessage(msg) {
         if (msg.type === 'warning' || msg.type === 'error') {
             this._emitter.emit(msg.type, msg[msg.type]);
+        } else if (msg.type === 'log') {
+            this._emitter.emit(msg.type, msg);
         } else {
             this._emitter.emit(msg.view_id, msg);
         }

--- a/test/utils/http-api.spec.js
+++ b/test/utils/http-api.spec.js
@@ -89,4 +89,17 @@ describe('http-api', () => {
         let runPromise = http.runJob('http://blah', {});
         return expect(runPromise).to.be.rejectedWith(/ENOTFOUND blah/);
     });
+    
+    it('create job call receives debug param', () => {
+        let addDebugLogs = true;
+        
+        nock(`${juttleServiceUrl}${API_PREFIX}`)
+            .post('/jobs', {debug: addDebugLogs})
+            .reply(200, {});
+
+        return http.runJob(juttleServiceUrl, {}, {}, addDebugLogs)
+        .catch((err) => {
+            throw new Error('Debug flag was not set: ' + err.message.substr(err.message.indexOf('{')));
+        });
+    });
 });


### PR DESCRIPTION
Adding debug log support.

One question is: should there be tests associated with this? I didn't find anything similar (there is successful call to runJob tested) so I thought I'd ask.

Notice the conflict: 
It's weird because the tests pass still. I noticed that when I make these same changes (happens without conflict) to master instead of `v0.6.0` there is an error when running the `juttle-engine-client`