### PR TITLE
Close websocket on job_end event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file documents all notable changes to juttle-client-library. The release nu
 
 ### Minor Changes
 - Change job-manager status to `CONNECTING`, `RUNNING` and `STOPPED`. Add subscribable `job-status` event to `job-manager` and `View` class. [#62](https://github.com/juttle/juttle-client-library/pull/62)
+- `job-manager`- close websocket when `job_end` message is received from juttle-service [#67](https://github.com/juttle/juttle-client-library/pull/67)
 
 ## 0.6.0
 

--- a/src/utils/job-manager.js
+++ b/src/utils/job-manager.js
@@ -93,8 +93,9 @@ export default class JobSocket extends EventTarget {
             this.send({
                 type: 'pong'
             });
-
             return;
+        } else if (msg.type === 'job_end') {
+            this.close();
         }
 
         this._emitter.emit('message', msg);

--- a/test/utils/job-manager.spec.js
+++ b/test/utils/job-manager.spec.js
@@ -11,12 +11,12 @@ chai.use(sinonChai);
 
 const API_PREFIX = '/api/v0';
 
-const bogusJobId = 'job-id';
-const bogusBundle = {
+const testJobId = 'job-id';
+const testBundle = {
     program: 'emit',
     modules: []
 };
-const bogusJobStart = {
+const testJobStart = {
     type: 'job_start',
     views: [{
         type: 'logger',
@@ -25,12 +25,12 @@ const bogusJobStart = {
 };
 
 function createSocketServer(jobStart, jobId) {
-    jobId = jobId || bogusJobId;
-    jobStart = jobStart || bogusJobStart;
+    jobId = jobId || testJobId;
+    jobStart = jobStart || testJobStart;
 
-    let mockSocketServer = new Server(`ws://localhost:8080${API_PREFIX}/jobs/${bogusJobId}`);
+    let mockSocketServer = new Server(`ws://localhost:8080${API_PREFIX}/jobs/${testJobId}`);
     mockSocketServer.on('connection', () => {
-        mockSocketServer.send(bogusJobStart);
+        mockSocketServer.send(testJobStart);
     });
 
     return mockSocketServer;
@@ -52,8 +52,8 @@ describe('job-socket', function() {
 
     beforeEach(() => {
         nock(`http://localhost:8080${API_PREFIX}`)
-            .post('/jobs', { bundle: bogusBundle })
-            .reply(200, { job_id: bogusJobId });
+            .post('/jobs', { bundle: testBundle })
+            .reply(200, { job_id: testJobId });
     });
 
     afterEach(() => {
@@ -69,7 +69,7 @@ describe('job-socket', function() {
         it('actually closes socket on stop', () => {
             mockSocketServer = createSocketServer();
 
-            return jobManager.start(bogusBundle)
+            return jobManager.start(testBundle)
             .then(() => {
                 expect(jobManager.status).to.equal(JobStatus.RUNNING);
                 return jobManager.close();
@@ -82,7 +82,7 @@ describe('job-socket', function() {
         it('sends back pong on ping', (done) => {
             mockSocketServer = createSocketServer();
 
-            jobManager.start(bogusBundle)
+            jobManager.start(testBundle)
             .then(() => {
                 mockSocketServer.on('message', (event) => {
                     expect(JSON.parse(event)).to.deep.equal({
@@ -98,7 +98,7 @@ describe('job-socket', function() {
         it('closes socket on job_end event', () => {
             mockSocketServer = createSocketServer();
 
-            return jobManager.start(bogusBundle)
+            return jobManager.start(testBundle)
             .then(() => {
                 expect(jobManager.status).to.equal(JobStatus.RUNNING);
 
@@ -126,7 +126,7 @@ describe('job-socket', function() {
             let cb = sinon.spy();
             jobManager.on('job-status', cb);
 
-            return jobManager.start(bogusBundle)
+            return jobManager.start(testBundle)
             .then(() => {
                 // send a bogus messages
                 mockSocketServer.send(JSDP.serialize({
@@ -156,7 +156,7 @@ describe('job-socket', function() {
             let cb = sinon.spy();
             jobManager.on('job-status', cb);
 
-            return jobManager.start(bogusBundle)
+            return jobManager.start(testBundle)
             .then(() => {
                 // send a bogus messages
                 mockSocketServer.send(JSDP.serialize({
@@ -184,7 +184,7 @@ describe('job-socket', function() {
 
             mockSocketServer = createSocketServer();
 
-            jobManager.start(bogusBundle)
+            jobManager.start(testBundle)
             .then((views) => {
                 jobManager.once('message', (payload) => {
                     expect(payload.time).to.be.a('date');
@@ -217,7 +217,7 @@ describe('job-socket', function() {
 
             mockSocketServer = createSocketServer();
 
-            jobManager.start(bogusBundle)
+            jobManager.start(testBundle)
             .then((views) => {
                 jobManager.once('message', (payload) => {
                     expect(payload.points).to.deep.equal(points);
@@ -272,7 +272,7 @@ describe('job-socket', function() {
                 views: views
             }));
 
-            jobManager.start(bogusBundle)
+            jobManager.start(testBundle)
             .then((views) => {
                 expect(views).to.deep.equal(views);
                 done();


### PR DESCRIPTION
Was experiencing this issue when trying to implement a better run button
on juttle-viewer. Currently we await the server to issue a close event,
and as a result was reporting the job as running (for several seconds), when it really had
recieved a `job_end` event.

It's better for the job-manager to close itself and immediately
get set to `STOPPED` state.

@go-oleg @VladVega @davidvgalbraith 