### PR TITLE
Add ecosystem link to juttle-client-library.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,13 @@
 
 [![Build Status](https://travis-ci.org/juttle/juttle-client-library.svg)](https://travis-ci.org/juttle/juttle-client-library)
 
-More to come.
+## Introduction
+
+juttle-client-library is a client-side Javascript application that interacts with [juttle-service](https://github.com/juttle/juttle-service) to execute juttle programs and render the results in the browser, including support for programmable input controls.
+
+## Ecosystem
+
+Here's how the juttle-client-library module fits into the overall [Juttle Ecosystem](https://github.com/juttle/juttle/blob/master/docs/juttle_ecosystem.md):
+
+[![Juttle Ecosystem](https://github.com/juttle/juttle/raw/master/docs/images/JuttleEcosystemDiagram.png)](https://github.com/juttle/juttle/blob/master/docs/juttle_ecosystem.md)
+


### PR DESCRIPTION
Add an ecosystem section to each README to show its part in the
overall architecture.

Also this README was empty, so add a minimal Introduction section that
copies the brief description from the ecosystem page.

@go-oleg @mnibecker 