### PR TITLE
date input: tether component popup to date input component instead of body

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "juttle-viz": "^0.5.0",
     "moment": "^2.11.1",
     "react": "^0.14.3",
-    "react-datepicker": "^0.18.0",
+    "react-datepicker": "^0.24.0",
     "react-dom": "^0.14.3",
     "react-redux": "^4.0.2",
     "react-select": "^1.0.0-beta8",

--- a/sass/main.scss
+++ b/sass/main.scss
@@ -39,13 +39,9 @@
     }
 }
 
-// This is outside of inputs view because the calendar popup
-// that react-datepicker creates is a child of the body instead
-// of the element in which the react-datepicker component resides.
-@import "../node_modules/react-datepicker/dist/react-datepicker";
-
 .inputs-view {
     @import "../node_modules/react-select/dist/react-select";
+    @import "../node_modules/react-datepicker/dist/react-datepicker";
 
     .duration-input {
         display: flex;

--- a/src/inputs/components/input-types/date-input.js
+++ b/src/inputs/components/input-types/date-input.js
@@ -1,8 +1,17 @@
 import React, { Component } from 'react';
+import ReactDOM from 'react-dom';
 import DatePicker from 'react-datepicker';
 import moment from 'moment';
 
 class DateInput extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            componentRootDOMNode: null
+        };
+    }
+
     handleChange(date) {
         // null values are passed if/when a user is editing
         // the text version of the date and it is invalid.
@@ -12,13 +21,21 @@ class DateInput extends Component {
         }
     }
 
+    componentDidMount() {
+        this.setState({
+            componentRootDOMNode: ReactDOM.findDOMNode(this)
+        });
+    }
+
     render() {
         let { value } = this.props.input;
 
         return (
             <div className='form-group'>
                 <DatePicker
+                    dateFormat='YYYY-MM-DD'
                     selected={moment.utc(value)}
+                    renderCalendarTo={this.state.componentRootDOMNode}
                     onChange={this.handleChange.bind(this)} />
             </div>
         );


### PR DESCRIPTION
Necessary so we can localize the datepicker styles to the inputs' DOM instead of the whole DOM. 

This became an issue in https://github.com/juttle/atom-juttle-viewer/pull/1 where some of the date picker styling was affecting atom's tabs.

- Had to bump the datepicker version to get support for this. The date display format changed so explicitly configuring it to what we had (YYYY-MM-DD).
- Not a huge fan of the `componentDidMount`/`setState` pattern to get the DOM node after the first render, but don't know of a better way to achieve this.

@mnibecker 