### PR TITLE
input -items option: allow array of strings

### DIFF
--- a/src/inputs/input-transformers.js
+++ b/src/inputs/input-transformers.js
@@ -1,0 +1,33 @@
+import _ from 'underscore';
+
+let normalizeItemsOption = (input) => {
+    if (!input.options.items) {
+        return input;
+    }
+
+    let options = Object.assign({}, input.options, {
+        items: input.options.items.map((item) => {
+            return _.isString(item) ? { value: item, label: item } : item;
+        })
+    });
+
+    return Object.assign({}, input, {
+        options: options
+    });
+
+};
+
+let transformers = {
+    normalizeItemsOption
+};
+
+let transformInput = (input) => {
+    return _.reduce(_.values(transformers), (input, transformer) => {
+        return transformer(input);
+    }, input);
+};
+
+export default {
+    transformers,
+    transformInput
+};

--- a/src/inputs/reducers.js
+++ b/src/inputs/reducers.js
@@ -1,11 +1,12 @@
 import { combineReducers } from 'redux';
+import inputTransformers from './input-transformers';
 
 import * as Actions from './actions';
 
-function inputs(state = [], action) {
+export function inputs(state = [], action) {
     switch (action.type) {
         case Actions.INPUT_DEFS_UPDATE:
-            return action.payload;
+            return action.payload.map(inputTransformers.transformInput);
         case Actions.CLEAR_INPUTS:
             return [];
         default:

--- a/test/inputs/input-transformers.spec.js
+++ b/test/inputs/input-transformers.spec.js
@@ -1,0 +1,54 @@
+import inputTransformers from '../../src/inputs/input-transformers';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+describe('input transformers', () => {
+    describe('normalizeItemsOption', () => {
+        it('converts string items to value, label', () => {
+            const inputDef = {
+                options: {
+                    items: [ 'value1', 'value2' ]
+                }
+            };
+
+            expect(inputTransformers.transformers.normalizeItemsOption(inputDef).options.items).to.deep.equal([
+                {
+                    value: 'value1',
+                    label: 'value1'
+                },
+                {
+                    value: 'value2',
+                    label: 'value2'
+                }
+            ]);
+        });
+
+        it('doesn not fail when no items present', () => {
+            const inputDef = {
+                options: {
+                }
+            };
+
+            expect(inputTransformers.transformers.normalizeItemsOption(inputDef).options.items).to.be.undefined;
+        });
+    });
+
+    describe('transformInput', () => {
+        it('uses the normalizeItemsOption transformer', () => {
+            const inputDef = {
+                options: {
+                    items: [ 'value1', 'value2' ]
+                }
+            };
+
+            let normalizeItemsOptionSpy = sinon.spy(inputTransformers.transformers, 'normalizeItemsOption');
+
+            inputTransformers.transformInput(inputDef);
+
+            expect(normalizeItemsOptionSpy.calledOnce).to.be.true;
+            expect(normalizeItemsOptionSpy.args[0]).to.deep.equal([inputDef]);
+
+            normalizeItemsOptionSpy.reset();
+        });
+    });
+});

--- a/test/inputs/reducers.spec.js
+++ b/test/inputs/reducers.spec.js
@@ -1,0 +1,41 @@
+import sinon from 'sinon';
+import inputTransformers from '../../src/inputs/input-transformers';
+import { expect } from 'chai';
+
+import * as reducers from '../../src/inputs/reducers';
+
+import { INPUT_DEFS_UPDATE } from '../../src/inputs/actions';
+
+describe('reducers', () => {
+    describe('input', () => {
+        it('inputs are run through transformers', () => {
+            let transformInputSpy = sinon.spy(inputTransformers, 'transformInput');
+
+            const inputDefs = [
+                {
+                    type: 'select',
+                    options: {
+                        items: [1,2,3]
+                    }
+                },
+                {
+                    type: 'select',
+                    options: {
+                        items: [4,5,6]
+                    }
+                }
+            ];
+
+            reducers.inputs(null, {
+                type: INPUT_DEFS_UPDATE,
+                payload: inputDefs
+            });
+
+            expect(transformInputSpy.calledTwice).to.be.true;
+            expect(transformInputSpy.args[0][0]).to.deep.equal(inputDefs[0]);
+            expect(transformInputSpy.args[1][0]).to.deep.equal(inputDefs[1]);
+
+            transformInputSpy.reset();
+        });
+    });
+});


### PR DESCRIPTION
Resolves https://github.com/juttle/juttle-client-library/issues/75.

Tried to implement this in a somewhat generic/extendible way so we can add other transformers/processors/normalizers later. This code may eventually move to the juttle layer via https://github.com/juttle/juttle/issues/148.

Couldn't come up with a better name than the generic term "transformers".

@mnibecker 